### PR TITLE
Add GitHub Actions workflow

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+exclude = settings.py

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,11 +1,8 @@
 name: Main pull request workflow
 on:
-  push:
+  pull_request:
     branches:
-      - feature/init_cicd
-  # pull_request:
-  #   branches:
-  #     - main
+      - main
 
 jobs:
   tests:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,43 @@
+name: Main pull request workflow
+on:
+  push:
+    branches:
+      - feature/init_cicd
+  # pull_request:
+  #   branches:
+  #     - main
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:13.10
+        env:
+          POSTGRES_USER: django_user
+          POSTGRES_PASSWORD: django_password
+          POSTGRES_DB: django_db
+        ports:
+          - 5432:5432
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: 3.11
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip 
+        pip install -r requirements.txt 
+    - name: Test with flake8 and django tests
+      env:
+        POSTGRES_USER: django_user
+        POSTGRES_PASSWORD: django_password
+        POSTGRES_DB: django_db
+        DB_HOST: 127.0.0.1
+        DB_PORT: 5432
+      run: |
+        python -m flake8 talent_reserves/
+        pytest

--- a/talent_reserves/api/admin.py
+++ b/talent_reserves/api/admin.py
@@ -1,3 +1,3 @@
-from django.contrib import admin
+# from django.contrib import admin
 
 # Register your models here.


### PR DESCRIPTION
Добавил workflow для GitHub Actions, который собирает образ вместе с postgresql (на будущее) и прогоняет два вида тестов: проверка `flake8 `(за исключением файла settings.py) и тесты, которые лежат в папке tests/ (вызывается команда `pytest`).

Также в файле api/admin убрал неиспользованный импорт (закомментировал), т.к. flake8 на него ругается. 