### PR TITLE
Create custom filter for coach model and remove bug from test_coach.py

### DIFF
--- a/talent_reserves/api/filters.py
+++ b/talent_reserves/api/filters.py
@@ -1,6 +1,7 @@
 import django_filters.rest_framework as django_filters
 
 from blog.models import Post
+from coaches.models import Coach
 
 
 class ListFilter(django_filters.Filter):
@@ -17,3 +18,11 @@ class PostFilter(django_filters.FilterSet):
     class Meta:
         model = Post
         fields = ('tags',)
+
+
+class CoachFilter(django_filters.FilterSet):
+    directions = ListFilter(field_name='directions__slug', lookup_expr='in')
+
+    class Meta:
+        model = Coach
+        fields = ('directions',)

--- a/talent_reserves/api/views.py
+++ b/talent_reserves/api/views.py
@@ -8,7 +8,7 @@ from blog.models import Post
 from coaches.models import Coach
 from news.models import News
 
-from .filters import PostFilter
+from .filters import PostFilter, CoachFilter
 from .pagination import BlogPagination, CoachPagination, NewsPagination
 from .serializers import CoachSerializer, NewsSerializer, PostSerializer
 
@@ -21,9 +21,9 @@ class CoachViewSet(viewsets.ReadOnlyModelViewSet):
     """
     queryset = Coach.objects.all()
     serializer_class = CoachSerializer
-    filter_backends = [DjangoFilterBackend]
-    filterset_fields = ['directions__slug', ]
     pagination_class = CoachPagination
+    filter_backends = [DjangoFilterBackend, ]
+    filterset_class = CoachFilter
 
 
 class NewsViewSet(viewsets.ReadOnlyModelViewSet):

--- a/tests/coaches/test_coach.py
+++ b/tests/coaches/test_coach.py
@@ -52,7 +52,7 @@ def test_coach_filtration(
     Тестирование фильтрации списка тренеров по направлению работы.
     Требуется вывести тренеров с направлением "бокс".
     """
-    response = api_client.get("/coaches/?directions__slug=box")
+    response = api_client.get("/coaches/?directions=box")
     data = response.json()
 
     assert len(data["results"]) == 2
@@ -61,7 +61,7 @@ def test_coach_filtration(
 
 
 @pytest.mark.django_db
-def test_coach_filtration(
+def test_coach_surname(
     api_client: APIClient,
     create_coaches: list[Coach],
     ) -> None:


### PR DESCRIPTION
**Тикет "Поправить фильтр Coaches"**

Что сделано:
1. Написан кастомный фильтр по полю directions модели Coaches через поле slug (чтобы отображалось в адресной строке не `/?directions__slug=box`, а коротко `/?directions=box`.
2. Исправил тесты под новый url для фильтрации.
3. Попутно исправил баг со своими тестами :smile: (два теста назывались одинаково, из-за чего первый из них никогда не запускался, а запускался только последний).